### PR TITLE
Fix typo in About section

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,7 +84,7 @@
     <div class="section">
       <h2>About the Project</h2>
       <p>CADALOC is an acronym for <strong>archaeothanatologiCAl re-evaluation of the burial in the roman flag sanctuary (aeDes) of Augustianis at the Later tOwn parish church's Crypt (traismauer/austria)</strong>. The project investigates a burial found in the crypt of the town parish church of Traismauer (Austria). It applies archaeothanatological, anthropological, archaeogenetic, and radiocarbon dating methods as well as, for visualizations, mobile 3d photogrammetry, machine learning, and virtual reconstruction to re-evaluate previous findings and enhance our understanding of the historical context.</p>
-      <p>Complimentary to the long-term archived data on PHAIDRA, this website serves as an <strong>interactive project archive</strong> for the CADALOC project, providing streamlined access to the research findings.</p>
+      <p>Complementary to the long-term archived data on PHAIDRA, this website serves as an <strong>interactive project archive</strong> for the CADALOC project, providing streamlined access to the research findings.</p>
           <p>
         To streamline implementation and optimize workflows regarding the visualization of 3d recorded objects, we use built-in viewers from apps like 
         <a href="https://poly.cam" target="_blank">Polycam</a> and platforms such as 


### PR DESCRIPTION
## Summary
- fix a typo in `index.html` line 87

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68428c6aa7148329bdf4d8a35833e416